### PR TITLE
Suggest to add project name as prefix in C/C++ header guards

### DIFF
--- a/C++CodeConventions.md
+++ b/C++CodeConventions.md
@@ -34,11 +34,11 @@ The actual implementation SHOULD be in .cpp files. The only exceptions to this a
 
 ### Examples
 #### Good Example
-Example for a file in /src/folder/SomeClass.h
+Example for a project called "My Project" with a file in /src/folder/SomeClass.h
 Note that the folder `src` is skipped, because all header and implementation files are in `src`.
 ``` cpp
-#ifndef FOLDER_SOME_CLASS_H
-#define FOLDER_SOME_CLASS_H
+#ifndef MYPROJECT_FOLDER_SOME_CLASS_H
+#define MYPROJECT_FOLDER_SOME_CLASS_H
 
 class SomeClass
 {


### PR DESCRIPTION
If you are making a generic library that can be used across projects, using folder + filenames along as C/C++ header guards don't guarantee unique. For example, for libraries and projects with encoding or crypto code, it makes total sense to do the following:
```
in OpenSSL:
    - src/crypto/sha1.h
in some other library:
    - src/crypto/sha1.h
in "My Project":
    - src/crypto/sha1.h
```
In this case, without the project prefix, if I use use any combinations of the above files, I get header guard conflicts:
```
#include <openssl/crypto/sha1.h>
#include <some-other-lib/crypto/sha1.h>  # won't work
```