### PR TITLE
Add a sample .editorconfig file

### DIFF
--- a/resources/embedded/.editorconfig
+++ b/resources/embedded/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+
+[*.yml]
+indent_size = 2
+
+[*.c, *.dts*, Makefile]
+indent_size = 8
+indent_style = tab


### PR DESCRIPTION
The .editorconfig file is only a helper config for a repository. It does
not enforce anything by itself, but does describe the indent style of a
repository. Some editors do need plugins, others support it natively
already. See editorconfig.org for more details.

Currently, it shows the used code-styles within Ultimaker.

* 1 tab (8 spaces wide) for C files and Makefiles, as the only C code
  and Makefiles that we really only have are U-Boot, busybox and the
  kernel.
* 2 spaces for yml (as that is the upstream default)
* 4 spaces for everything else

Of course, every project, even every subdirectory can modify this file
to suit their needs. This file just gives us some sane defaults.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>