### PR TITLE
Add indentation exception for YAML files

### DIFF
--- a/resources/web/.editorconfig
+++ b/resources/web/.editorconfig
@@ -15,3 +15,7 @@ indent_style = tab
 [*.md]
 # 2 trailing spaces in Markdown are a newline
 trim_trailing_whitespace = false
+
+[*.y{,a}ml]
+indent_size = 2
+


### PR DESCRIPTION
YAML doesn't care about how many spaces are used for indentation as long as it is consistent. Most examples seem to use 2 spaces indentation however.